### PR TITLE
dom-selectors-moved

### DIFF
--- a/src/DOM-loader.js
+++ b/src/DOM-loader.js
@@ -6,24 +6,24 @@ let domDisplay = {
 
   createDailyActivityData(id, activityInfo, dateString, userRepo) {
     const userDailyFlights = activityInfo.getDailyUserData(id, dateString, userRepo, 'flightsOfStairs');
-    userStairsToday.insertAdjacentHTML("afterBegin", `<p>Stair Count:</p><p>You</><p><span class="number">${userDailyFlights}</span></p>`);
+    document.getElementById('userStairsToday').insertAdjacentHTML("afterBegin", `<p>Stair Count:</p><p>You</><p><span class="number">${userDailyFlights}</span></p>`);
     const usersAverageDailyFlights = activityInfo.getAllUsersAverageForDay(dateString, userRepo, 'flightsOfStairs');
-    avgStairsToday.insertAdjacentHTML("afterBegin", `<p>Stair Count: </p><p>All Users</p><p><span class="number">${usersAverageDailyFlights}</span></p>`);
+    document.getElementById('avgStairsToday').insertAdjacentHTML("afterBegin", `<p>Stair Count: </p><p>All Users</p><p><span class="number">${usersAverageDailyFlights}</span></p>`);
     const userSteps = activityInfo.getDailyUserData(id, dateString, userRepo, 'numSteps');
-    userStepsToday.insertAdjacentHTML("afterBegin", `<p>Step Count:</p><p>You</p><p><span class="number">${userSteps}</span></p>`);
+    document.getElementById('userStepsToday').insertAdjacentHTML("afterBegin", `<p>Step Count:</p><p>You</p><p><span class="number">${userSteps}</span></p>`);
     const usersAverageDailySteps = activityInfo.getAllUsersAverageForDay(dateString, userRepo, 'numSteps');
-    avgStepsToday.insertAdjacentHTML("afterBegin", `<p>Step Count:</p><p>All Users</p><p><span class="number">${usersAverageDailyFlights}</span></p>`);
+    document.getElementById('avgStepsToday').insertAdjacentHTML("afterBegin", `<p>Step Count:</p><p>All Users</p><p><span class="number">${usersAverageDailyFlights}</span></p>`);
   },
 
   createWeeklyActivityData(id, activityInfo, dateString, userRepo, winnerId, user) {
     const weeklySteps = domDisplay.makeActivityHTML(activityInfo.getWeeklyUserData(id, dateString, userRepo, "numSteps"), "steps");
-    userStepsThisWeek.insertAdjacentHTML("afterBegin", weeklySteps);
+    document.getElementById('userStepsThisWeek').insertAdjacentHTML("afterBegin", weeklySteps);
     const weeklyFlights = domDisplay.makeActivityHTML(activityInfo.getWeeklyUserData(id, dateString, userRepo, "flightsOfStairs"), "flights");
-    userStairsThisWeek.insertAdjacentHTML("afterBegin", weeklyFlights);
+    document.getElementById('userStairsThisWeek').insertAdjacentHTML("afterBegin", weeklyFlights);
     const minutesActive = domDisplay.makeActivityHTML(activityInfo.getWeeklyUserData(id, dateString, userRepo, "minutesActive"), "minutes");
-    userMinutesThisWeek.insertAdjacentHTML("afterBegin", minutesActive);
+    document.getElementById('userMinutesThisWeek').insertAdjacentHTML("afterBegin", minutesActive);
     const bestSteps = domDisplay.makeActivityHTML(activityInfo.getWeeklyUserData(winnerId, dateString, userRepo, "numSteps"), 'steps');
-    bestUserSteps.insertAdjacentHTML("afterBegin", bestSteps);
+    document.getElementById('bestUserSteps').insertAdjacentHTML("afterBegin", bestSteps);
   }
 
 };

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -46,49 +46,11 @@ const activityNumStepsInfo = document.getElementById('activity-numSteps-input')
 const activityMinsActiveInfo = document.getElementById('activity-minsActive-input')
 const activityFlightsOfStairsInfo = document.getElementById('activity-flightsOfStairs-input')
 
-const sidebarName = document.getElementById('sidebarUserName');
-const stepGoalCard = document.getElementById('userStepGoalCard');
-const avStepGoalCard = document.getElementById('averageStepsGoalCard');
-const headerText = document.getElementById('headerText');
-const userAddress = document.getElementById('userAddress');
-const userEmail = document.getElementById('userEmail');
-const userStridelength = document.getElementById('userStridelength');
-const friendList = document.getElementById('friendList');
-const hydrationToday = document.getElementById('hydrationToday');
-const hydrationAverage = document.getElementById('hydrationAverage');
-const hydrationThisWeek = document.getElementById('hydrationThisWeek');
-const hydrationEarlierWeek = document.getElementById('hydrationEarlierWeek');
-const historicalWeek = document.querySelectorAll('.historicalWeek');
-const sleepToday = document.getElementById('sleepToday');
-const sleepQualityToday = document.getElementById('sleepQualityToday');
-const avUserSleepQuality = document.getElementById('avUserSleepQuality');
-const sleepThisWeek = document.getElementById('sleepThisWeek');
-const sleepEarlierWeek = document.getElementById('sleepEarlierWeek');
-const friendChallengeListToday = document.getElementById('friendChallengeListToday');
-const friendChallengeListHistory = document.getElementById('friendChallengeListHistory');
-const bigWinner = document.getElementById('bigWinner');
-const userStepsToday = document.getElementById('userStepsToday');
-const avgStepsToday = document.getElementById('avgStepsToday');
-const userStairsToday = document.getElementById('userStairsToday');
-const avgStairsToday = document.getElementById('avgStairsToday');
-const userMinutesToday = document.getElementById('userMinutesToday');
-const avgMinutesToday = document.getElementById('avgMinutesToday');
-const userStepsThisWeek = document.getElementById('userStepsThisWeek');
-const userStairsThisWeek = document.getElementById('userStairsThisWeek');
-const userMinutesThisWeek = document.getElementById('userMinutesThisWeek');
-const bestUserSteps = document.getElementById('bestUserSteps');
-const streakList = document.getElementById('streakList');
-const streakListMinutes = document.getElementById('streakListMinutes')
-
 document.querySelector('#submit-sleep-info').addEventListener('click', fetchApi.postSleepData);
 document.querySelector('#submit-hydration-info').addEventListener('click', fetchApi.postHydrationData);
 document.querySelector('#submit-activity-info').addEventListener('click', fetchApi.postActivityData);
 
 function startApp() {
-  getCurrentInfo();
-};
-
-function getCurrentInfo() {
   const userNowId = Math.floor(Math.random() * 50);
   const userNow = userRepo.getUserFromID(userNowId);
   const today = userRepo.getCurrentDate(userNowId, hydrationRepo.hydrationData);
@@ -103,7 +65,7 @@ function displayUserInfo(userNow, userNowId, today, randomHistory, winnerNow) {
   addSleepInfo(userNowId, sleepRepo, today, userRepo, randomHistory);
   addActivityInfo(userNowId, activityRepo, today, userRepo, randomHistory, userNow, winnerNow);
   addFriendGameInfo(userNowId, activityRepo, userRepo, today, randomHistory, userNow);
-  historicalWeek.forEach(instance => instance.insertAdjacentHTML('afterBegin', `Week of ${randomHistory}`));
+  document.querySelectorAll('.historicalWeek').forEach(instance => instance.insertAdjacentHTML('afterBegin', `Week of ${randomHistory}`));
 };
 
 function createUsers(userData) {
@@ -115,14 +77,14 @@ function createUsers(userData) {
 };
 
 function addInfoToSidebar(user, userRepo) {
-  sidebarName.innerText = user.name;
-  headerText.innerText = `${user.getFirstName()}'s Activity Tracker`;
-  stepGoalCard.innerText = `Your daily step goal is ${user.dailyStepGoal}.`;
-  avStepGoalCard.innerText = `The average daily step goal is ${userRepo.calculateAverageStepGoal()}.`;
-  userAddress.innerText = user.address;
-  userEmail.innerText = user.email;
-  userStridelength.innerText = `Your stridelength is ${user.strideLength} meters.`;
-  friendList.insertAdjacentHTML('afterBegin', makeFriendHTML(user, userRepo));
+  document.getElementById('sidebarUserName').innerText = user.name;
+  document.getElementById('headerText').innerText = `${user.getFirstName()}'s Activity Tracker`;
+  document.getElementById('userStepGoalCard').innerText = `Your daily step goal is ${user.dailyStepGoal}.`;
+  document.getElementById('averageStepsGoalCard').innerText = `The average daily step goal is ${userRepo.calculateAverageStepGoal()}.`;
+  document.getElementById('userAddress').innerText = user.address;
+  document.getElementById('userEmail').innerText = user.email;
+  document.getElementById('userStridelength').innerText = `Your stridelength is ${user.strideLength} meters.`;
+  document.getElementById('friendList').insertAdjacentHTML('afterBegin', makeFriendHTML(user, userRepo));
 };
 
 function makeFriendHTML(user, userRepo) {
@@ -138,13 +100,13 @@ function getRandomDate(userRepo, id, dataSet) {
 
 function addHydrationInfo(id, hydrationInfo, dateString, userRepo, laterDateString) {
   const dailyOunces = hydrationInfo.calculateDailyTotal(id, dateString, 'numOunces');
-  hydrationToday.insertAdjacentHTML('afterBegin', `<p>You drank</p><p><span class="number">${dailyOunces}</span></p><p>oz water today.</p>`);
+  document.getElementById('hydrationToday').insertAdjacentHTML('afterBegin', `<p>You drank</p><p><span class="number">${dailyOunces}</span></p><p>oz water today.</p>`);
   const averageOunces = hydrationInfo.calculateAverage(id, 'numOunces');
-  hydrationAverage.insertAdjacentHTML('afterBegin', `<p>Your average water intake is</p><p><span class="number">${averageOunces}</span></p> <p>oz per day.</p>`);
+  document.getElementById('hydrationAverage').insertAdjacentHTML('afterBegin', `<p>Your average water intake is</p><p><span class="number">${averageOunces}</span></p> <p>oz per day.</p>`);
   const firstWeekOunces = hydrationInfo.calculateFirstWeekOunces(userRepo, id);
-  hydrationThisWeek.insertAdjacentHTML('afterBegin', makeHydrationHTML(id, hydrationInfo, userRepo, firstWeekOunces));
+  document.getElementById('hydrationThisWeek').insertAdjacentHTML('afterBegin', makeHydrationHTML(id, hydrationInfo, userRepo, firstWeekOunces));
   const randomWeekOunces = hydrationInfo.calculateRandomWeekOunces(laterDateString, id, userRepo);
-  hydrationEarlierWeek.insertAdjacentHTML('afterBegin', makeHydrationHTML(id, hydrationInfo, userRepo, randomWeekOunces));
+  document.getElementById('hydrationEarlierWeek').insertAdjacentHTML('afterBegin', makeHydrationHTML(id, hydrationInfo, userRepo, randomWeekOunces));
 };
 
 function makeHydrationHTML(id, hydrationInfo, userRepo, relevantData) {
@@ -154,15 +116,15 @@ function makeHydrationHTML(id, hydrationInfo, userRepo, relevantData) {
 
 function addSleepInfo(id, sleepInfo, dateString, userRepo) {
   const sleepHours = sleepInfo.calculateDailyTotal(id, dateString, 'hoursSlept');
-  sleepToday.insertAdjacentHTML("afterBegin", `<p>You slept</p> <p><span class="number">${sleepHours}</span></p> <p>hours today.</p>`);
+  document.getElementById('sleepToday').insertAdjacentHTML("afterBegin", `<p>You slept</p> <p><span class="number">${sleepHours}</span></p> <p>hours today.</p>`);
   const sleepQuality = sleepInfo.calculateDailyTotal(id, dateString, 'sleepQuality');
-  sleepQualityToday.insertAdjacentHTML("afterBegin", `<p>Your sleep quality was</p> <p><span class="number">${sleepQuality}</span></p><p>out of 5.</p>`);
+  document.getElementById('sleepQualityToday').insertAdjacentHTML("afterBegin", `<p>Your sleep quality was</p> <p><span class="number">${sleepQuality}</span></p><p>out of 5.</p>`);
   const averageSleepQuality = Math.round(sleepInfo.calculateAllUserSleepQuality() *100)/100;
-  avUserSleepQuality.insertAdjacentHTML("afterBegin", `<p>The average user's sleep quality is</p> <p><span class="number">${averageSleepQuality}</span></p><p>out of 5.</p>`);
+  document.getElementById('avUserSleepQuality').insertAdjacentHTML("afterBegin", `<p>The average user's sleep quality is</p> <p><span class="number">${averageSleepQuality}</span></p><p>out of 5.</p>`);
   const weekSleepTotal = sleepInfo.calculateWeekTotal(dateString, id, userRepo, 'hoursSlept');
-  sleepThisWeek.insertAdjacentHTML('afterBegin', makeSleepHTML(id, sleepInfo, userRepo, weekSleepTotal));
+  document.getElementById('sleepThisWeek').insertAdjacentHTML('afterBegin', makeSleepHTML(id, sleepInfo, userRepo, weekSleepTotal));
   const weekSleepQuality = sleepInfo.calculateWeekTotal(dateString, id, userRepo, 'sleepQuality');
-  sleepEarlierWeek.insertAdjacentHTML('afterBegin', makeSleepHTML(id, sleepInfo, userRepo, weekSleepQuality));
+  document.getElementById('sleepEarlierWeek').insertAdjacentHTML('afterBegin', makeSleepHTML(id, sleepInfo, userRepo, weekSleepQuality));
 };
 
 function makeSleepHTML(id, sleepInfo, userRepo, relevantData) {
@@ -172,24 +134,24 @@ function makeSleepHTML(id, sleepInfo, userRepo, relevantData) {
 
 function addActivityInfo(id, activityInfo, dateString, userRepo, winnerId, user) {
   const userDailyActiveMinutes = activityInfo.getDailyUserData(id, dateString, userRepo, 'minutesActive');
-  userMinutesToday.insertAdjacentHTML("afterBegin", `<p>Active Minutes:</p><p>You</p><p><span class="number">${userDailyActiveMinutes}</span></p>`);
+  document.getElementById('userMinutesToday').insertAdjacentHTML("afterBegin", `<p>Active Minutes:</p><p>You</p><p><span class="number">${userDailyActiveMinutes}</span></p>`);
   const usersAverage = activityInfo.getAllUsersAverageForDay(dateString, userRepo, 'minutesActive');
-  avgMinutesToday.insertAdjacentHTML("afterBegin", `<p>Active Minutes:</p><p>All Users</p><p><span class="number">${usersAverage}</span></p>`);
+  document.getElementById('avgMinutesToday').insertAdjacentHTML("afterBegin", `<p>Active Minutes:</p><p>All Users</p><p><span class="number">${usersAverage}</span></p>`);
   domDisplay.createDailyActivityData(id, activityInfo, dateString, userRepo);
   domDisplay.createWeeklyActivityData(id, activityInfo, dateString, userRepo, winnerId, user);
 };
 
 function addFriendGameInfo(id, activityInfo, userRepo, dateString, laterDateString, user) {
   const challengeWinner = activityInfo.getChallengeListAndWinner(user, dateString, userRepo);
-  friendChallengeListToday.insertAdjacentHTML("afterBegin", makeFriendChallengeHTML(id, challengeWinner));
+  document.getElementById('friendChallengeListToday').insertAdjacentHTML("afterBegin", makeFriendChallengeHTML(id, challengeWinner));
   const stepStreak = activityInfo.getStreakDays(userRepo, id, 'numSteps');
-  streakList.insertAdjacentHTML("afterBegin", makeStepStreakHTML(id, stepStreak));
+  document.getElementById('streakList').insertAdjacentHTML("afterBegin", makeStepStreakHTML(id, stepStreak));
   const minutesStreak = activityInfo.getStreakDays(userRepo, id, 'minutesActive');
-  streakListMinutes.insertAdjacentHTML("afterBegin", makeStepStreakHTML(id, minutesStreak));
+  document.getElementById('streakListMinutes').insertAdjacentHTML("afterBegin", makeStepStreakHTML(id, minutesStreak));
   const challengeList = activityInfo.getChallengeListAndWinner(user, dateString, userRepo);
-  friendChallengeListHistory.insertAdjacentHTML("afterBegin", makeFriendChallengeHTML(id, challengeList));
+  document.getElementById('friendChallengeListHistory').insertAdjacentHTML("afterBegin", makeFriendChallengeHTML(id, challengeList));
   const winnerInfo = activityInfo.showcaseWinner(user, dateString, userRepo);
-  bigWinner.insertAdjacentHTML('afterBegin', `THIS WEEK'S WINNER! ${winnerInfo} steps`);
+  document.getElementById('bigWinner').insertAdjacentHTML('afterBegin', `THIS WEEK'S WINNER! ${winnerInfo} steps`);
 }
 
 function makeFriendChallengeHTML(id, relevantData) {


### PR DESCRIPTION
## What is the change?
Dom selectors moved 
## Is this a fix or a feature? 
The selectors move to 'just-in-time' . Most all selectors were only used once. We can move the selector targets simply inside each function. 
## Where should the reviewer start?
* line 9 dom-loader.js
* line 49 scripts.js
## How should this be tested?
Run `npm start` in your terminal and make sure all content loads and console is clear of bugs 

@brycemara @dietza @coopterrones
